### PR TITLE
Optionally disable adopted sd encryption.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -102,6 +102,10 @@ common_shared_libraries += libcryptfs_hw
 LOCAL_CFLAGS += -DCONFIG_HW_DISK_ENCRYPTION
 endif
 
+ifeq ($(TARGET_NO_SD_ADOPT_ENCRYPTION),true)
+LOCAL_CFLAGS += -DCONFIG_NO_SD_ADOPT_ENCRYPTION
+endif
+
 LOCAL_SHARED_LIBRARIES := $(common_shared_libraries)
 LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 

--- a/Disk.cpp
+++ b/Disk.cpp
@@ -155,11 +155,12 @@ void Disk::createPrivateVolume(dev_t device, const std::string& partGuid) {
     }
 
     std::string keyRaw;
+#ifndef CONFIG_NO_SD_ADOPT_ENCRYPTION
     if (!ReadFileToString(BuildKeyPath(normalizedGuid), &keyRaw)) {
         PLOG(ERROR) << "Failed to load key for GUID " << normalizedGuid;
         return;
     }
-
+#endif
     LOG(DEBUG) << "Found key for GUID " << normalizedGuid;
 
     auto vol = std::shared_ptr<VolumeBase>(new PrivateVolume(device, keyRaw));

--- a/PrivateVolume.cpp
+++ b/PrivateVolume.cpp
@@ -64,7 +64,9 @@ status_t PrivateVolume::doCreate() {
     if (CreateDeviceNode(mRawDevPath, mRawDevice)) {
         return -EIO;
     }
-
+#ifdef CONFIG_NO_SD_ADOPT_ENCRYPTION
+    mDmDevPath = mRawDevPath;
+#else
     // Recover from stale vold by tearing down any old mappings
     cryptfs_revert_ext_volume(getId().c_str());
 
@@ -79,7 +81,7 @@ status_t PrivateVolume::doCreate() {
         PLOG(ERROR) << getId() << " failed to setup cryptfs";
         return -EIO;
     }
-
+#endif
     return OK;
 }
 


### PR DESCRIPTION
Benefits
- Improves speed for adopted sd
- Dont loose data of sd if you wipe /data
- Use same SD in other devices

device needs to have TARGET_NO_SD_ADOPT_ENCRYPTION := true to enable it

/data/system/storage.xml needs to be backed up and restored after /data wipe for storage to be mounted as primary
/data/system/packages.list and packages.xml needs to be backed up and restored after /data wipe for apps on adopted sd to work

Change-Id: I4777b8e50509971cba9643ff5906d636da4eca4a
